### PR TITLE
Don't mutate state in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,14 @@ var reducer = createReducer(handlers)
 
 // actual action handling functions, down out of the way.
 function add (state, action) {
-  state.num += action.num
-  return state
+  return {
+    num: state.num + action.num
+  }
 }
 
 function multiply (state, action) {
-  state.num *= action.num
-  return state
+  return {
+    num: state.num * action.num
+  }
 }
 ```


### PR DESCRIPTION
If this utility is meant for Redux, it's best to avoid mutability in examples.
We don't support it in Redux.
